### PR TITLE
Introduce ethsign msg, allowing signing of arbitrary data

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "ethsign-${version}";
-  version = "0.8.2";
+  version = "0.9.0";
 
   goPackagePath = "github.com/dapphub/ethsign";
   hardeningDisable = ["fortify"];

--- a/ethsign.go
+++ b/ethsign.go
@@ -1,26 +1,70 @@
 package main
 
 import (
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/accounts/usbwallet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"os"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"runtime"
 	"strings"
 	"syscall"
-	"runtime"
-	
+
 	"gopkg.in/urfave/cli.v1"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
+
+// https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L373
+// signHash is a helper function that calculates a hash for the given message that can be
+// safely used to calculate a signature from.
+//
+// The hash is calculated as
+//   keccak256("\x19Ethereum Signed Message:\n"${message length}${message}).
+//
+// This gives context to the signed message and prevents signing of transactions.
+func signHash(data []byte) []byte {
+	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(data), data)
+	return crypto.Keccak256([]byte(msg))
+}
+
+func getWallets(store []string, defaultKeyStores []string) []accounts.Wallet {
+	backends := []accounts.Backend{}
+
+	var paths []string
+	if len(store) == 0 {
+		paths = defaultKeyStores
+	} else {
+		paths = store
+	}
+	for _, x := range paths {
+		ks := keystore.NewKeyStore(
+			x, keystore.StandardScryptN, keystore.StandardScryptP)
+		backends = append(backends, ks)
+	}
+
+	if ledgerhub, err := usbwallet.NewLedgerHub(); err != nil {
+		fmt.Fprintf(os.Stderr, "ethsign: failed to look for USB Ledgers")
+	} else {
+		backends = append(backends, ledgerhub)
+	}
+	if trezorhub, err := usbwallet.NewTrezorHub(); err != nil {
+		fmt.Fprintf(os.Stderr, "ethsign: failed to look for USB Trezors")
+	} else {
+		backends = append(backends, trezorhub)
+	}
+
+	manager := accounts.NewManager(backends...)
+	return manager.Wallets()
+}
 
 func main() {
 	var defaultKeyStores cli.StringSlice
@@ -41,54 +85,30 @@ func main() {
 			os.Getenv("HOME") + "/.local/share/io.parity.ethereum/keys/ethereum",
 		}
 	}
-	
+
 	app := cli.NewApp()
 	app.Name = "ethsign"
 	app.Usage = "sign Ethereum transactions using a JSON keyfile"
-	app.Version = "0.8.2"
-	app.Commands = []cli.Command {
-		cli.Command {
-			Name: "list-accounts",
+	app.Version = "0.9.0"
+	app.Commands = []cli.Command{
+		cli.Command{
+			Name:    "list-accounts",
 			Aliases: []string{"ls"},
-			Usage: "list accounts in keystore and USB wallets",
+			Usage:   "list accounts in keystore and USB wallets",
 			Flags: []cli.Flag{
 				cli.StringSliceFlag{
-					Name: "key-store",
-					Usage: "path to key store",
+					Name:   "key-store",
+					Usage:  "path to key store",
 					EnvVar: "ETH_KEYSTORE",
 				},
 			},
 			Action: func(c *cli.Context) error {
-				backends := []accounts.Backend{}
 
-				var paths []string
-				if len(c.StringSlice("key-store")) == 0 {
-					paths = defaultKeyStores
-				} else {
-					paths = c.StringSlice("key-store")
-				}
-				for _, x := range(paths) {
-					ks := keystore.NewKeyStore(
-						x, keystore.StandardScryptN, keystore.StandardScryptP)
-					backends = append(backends, ks)
-				}
+				wallets := getWallets(c.StringSlice("key-store"), defaultKeyStores)
 
-				if ledgerhub, err := usbwallet.NewLedgerHub(); err != nil {
-					fmt.Fprintf(os.Stderr, "ethsign: failed to look for USB Ledgers")
-				} else {
-					backends = append(backends, ledgerhub)
-				}
-				if trezorhub, err := usbwallet.NewTrezorHub(); err != nil {
-					fmt.Fprintf(os.Stderr, "ethsign: failed to look for USB Trezors")
-				} else {
-					backends = append(backends, trezorhub)
-				}
-
-				manager := accounts.NewManager(backends...)
-				wallets := manager.Wallets()
-				for _, x := range(wallets) {
+				for _, x := range wallets {
 					if x.URL().Scheme == "keystore" {
-						for _, y := range(x.Accounts()) {
+						for _, y := range x.Accounts() {
 							fmt.Printf("%s keystore\n", y.Address.Hex())
 						}
 					} else if x.URL().Scheme == "ledger" {
@@ -99,66 +119,65 @@ func main() {
 							z, err := x.Derive(path, false)
 							if err != nil {
 								return cli.NewExitError("ethsign: couldn't use Ledger: needs to be in Ethereum app with browser support off", 1)
-							} else {
-								fmt.Printf("%s ledger-%s\n", z.Address.Hex(), pathstr)
 							}
+							fmt.Printf("%s ledger-%s\n", z.Address.Hex(), pathstr)
 						}
 					}
 				}
-				
+
 				return nil
 			},
 		},
 
-		cli.Command {
-			Name: "transaction",
+		cli.Command{
+			Name:    "transaction",
 			Aliases: []string{"tx"},
-			Usage: "make a signed transaction",
+			Usage:   "make a signed transaction",
 			Flags: []cli.Flag{
 				cli.StringSliceFlag{
-					Name: "key-store",
-					Usage: "path to key store",
+					Name:   "key-store",
+					Usage:  "path to key store",
 					EnvVar: "ETH_KEYSTORE",
 				},
 				cli.BoolFlag{
-					Name: "create",
+					Name:  "create",
 					Usage: "make a contract creation transaction",
 				},
 				cli.StringFlag{
-					Name: "from",
-					Usage: "address of signing account",
+					Name:   "from",
+					Usage:  "address of signing account",
 					EnvVar: "ETH_FROM",
 				},
 				cli.StringFlag{
-					Name: "passphrase-file",
+					Name:  "passphrase-file",
 					Usage: "path to file containing account passphrase",
 				},
 				cli.StringFlag{
-					Name: "chain-id",
+					Name:  "chain-id",
 					Usage: "chain ID",
 				},
 				cli.StringFlag{
-					Name: "to",
+					Name:  "to",
 					Usage: "account of recipient",
 				},
 				cli.StringFlag{
-					Name: "nonce",
+					Name:  "nonce",
 					Usage: "account nonce",
 				},
 				cli.StringFlag{
-					Name: "gas-price",
+					Name:  "gas-price",
 					Usage: "gas price",
 				},
 				cli.StringFlag{
-					Name: "gas-limit",
+					Name:  "gas-limit",
 					Usage: "gas limit",
 				},
 				cli.StringFlag{
-					Name: "value",
+					Name:  "value",
 					Usage: "transaction value",
 				},
 				cli.StringFlag{
-					Name: "data",
+					Name:  "data",
 					Usage: "hex data",
 				},
 			},
@@ -167,19 +186,19 @@ func main() {
 					"nonce", "value", "gas-price", "gas-limit", "chain-id", "from",
 				}
 
-				for _, required := range(requireds) {
+				for _, required := range requireds {
 					if c.String(required) == "" {
-						return cli.NewExitError("ethsign: missing required parameter --" + required, 1)
+						return cli.NewExitError("ethsign: missing required parameter --"+required, 1)
 					}
 				}
 
 				create := c.Bool("create")
-				
+
 				if (c.String("to") == "" && !create) || (c.String("to") != "" && create) {
 					return cli.NewExitError("ethsign: need exactly one of --to or --create", 1)
 				}
 
-				if (create && c.String("data") == "") {
+				if create && c.String("data") == "" {
 					return cli.NewExitError("ethsign: need --data when doing --create", 1)
 				}
 
@@ -187,53 +206,28 @@ func main() {
 				from := common.HexToAddress(c.String("from"))
 				nonce := math.MustParseUint64(c.String("nonce"))
 				gasPrice := math.MustParseBig256(c.String("gas-price"))
-				gasLimit := math.MustParseBig256(c.String("gas-limit"))
+				gasLimit := math.MustParseUint64(c.String("gas-limit"))
 				value := math.MustParseBig256(c.String("value"))
 				chainID := math.MustParseBig256(c.String("chain-id"))
-				
+
 				dataString := c.String("data")
 				if dataString == "" {
 					dataString = "0x"
 				}
 				data := hexutil.MustDecode(dataString)
-				
-				backends := []accounts.Backend{ }
 
-				var paths []string
-				if len(c.StringSlice("key-store")) == 0 {
-					paths = defaultKeyStores
-				} else {
-					paths = c.StringSlice("key-store")
-				}
-				for _, x := range(paths) {
-					ks := keystore.NewKeyStore(
-						x, keystore.StandardScryptN, keystore.StandardScryptP)
-					backends = append(backends, ks)
-				}
+				wallets := getWallets(c.StringSlice("key-store"), defaultKeyStores)
 
-				if ledgerhub, err := usbwallet.NewLedgerHub(); err != nil {
-					fmt.Fprintf(os.Stderr, "ethsign: failed to look for USB Ledgers")
-				} else {
-					backends = append(backends, ledgerhub)
-				}
-				if trezorhub, err := usbwallet.NewTrezorHub(); err != nil {
-					fmt.Fprintf(os.Stderr, "ethsign: failed to look for USB Trezors")
-				} else {
-					backends = append(backends, trezorhub)
-				}
-
-				manager := accounts.NewManager(backends...)
-				wallets := manager.Wallets()
 				var wallet accounts.Wallet
 				var acct *accounts.Account
 
 				needPassphrase := true
 
-				Scan:
-				for _, x := range(wallets) {
+			Scan:
+				for _, x := range wallets {
 					if x.URL().Scheme == "keystore" {
-						for _, y := range(x.Accounts()) {
-							if (y.Address == from) {
+						for _, y := range x.Accounts() {
+							if y.Address == from {
 								wallet = x
 								acct = &y
 								break Scan
@@ -247,13 +241,12 @@ func main() {
 							y, err := x.Derive(path, true)
 							if err != nil {
 								return cli.NewExitError("ethsign: Ledger needs to be in Ethereum app with browser support off", 1)
-							} else {
-								if y.Address == from {
-									wallet = x
-									acct = &y
-									needPassphrase = false
-									break Scan
-								}
+							}
+							if y.Address == from {
+								wallet = x
+								acct = &y
+								needPassphrase = false
+								break Scan
 							}
 						}
 					}
@@ -266,7 +259,6 @@ func main() {
 					)
 				}
 
-
 				passphrase := ""
 
 				if needPassphrase {
@@ -275,16 +267,15 @@ func main() {
 						if err != nil {
 							return cli.NewExitError("ethsign: failed to read passphrase file", 1)
 						}
-						
+
 						passphrase = strings.TrimSuffix(string(passphraseFile), "\n")
 					} else {
 						fmt.Fprintf(os.Stderr, "Ethereum account passphrase (not echoed): ")
 						bytes, err := terminal.ReadPassword(int(syscall.Stdin))
 						if err != nil {
 							return cli.NewExitError("ethsign: failed to read passphrase", 1)
-						} else {
-							passphrase = string(bytes)
 						}
+						passphrase = string(bytes)
 					}
 				} else {
 					fmt.Fprintf(os.Stderr, "Waiting for hardware wallet confirmation...\n")
@@ -296,7 +287,7 @@ func main() {
 				} else {
 					tx = types.NewTransaction(nonce, to, value, gasLimit, gasPrice, data)
 				}
-				
+
 				signed, err := wallet.SignTxWithPassphrase(*acct, passphrase, tx, chainID)
 				if err != nil {
 					return cli.NewExitError("ethsign: failed to sign tx", 1)
@@ -304,11 +295,133 @@ func main() {
 
 				encoded, _ := rlp.EncodeToBytes(signed)
 				fmt.Println(hexutil.Encode(encoded[:]))
-				
+
+				return nil
+			},
+		},
+
+		cli.Command{
+			Name:    "message",
+			Aliases: []string{"msg"},
+			Usage:   "sign arbitrary data with header prefix",
+			Flags: []cli.Flag{
+				cli.StringSliceFlag{
+					Name:   "key-store",
+					Usage:  "path to key store",
+					EnvVar: "ETH_KEYSTORE",
+				},
+				cli.StringFlag{
+					Name:   "from",
+					Usage:  "address of signing account",
+					EnvVar: "ETH_FROM",
+				},
+				cli.StringFlag{
+					Name:  "passphrase-file",
+					Usage: "path to file containing account passphrase",
+				},
+				cli.StringFlag{
+					Name:  "data",
+					Usage: "hex data to sign",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				requireds := []string{
+					"from", "data",
+				}
+
+				for _, required := range requireds {
+					if c.String(required) == "" {
+						return cli.NewExitError("ethsign: missing required parameter --"+required, 1)
+					}
+				}
+
+				from := common.HexToAddress(c.String("from"))
+
+				dataString := c.String("data")
+				if !strings.HasPrefix(dataString, "0x") {
+					dataString = "0x" + dataString
+				}
+				data := hexutil.MustDecode(dataString)
+
+				wallets := getWallets(c.StringSlice("key-store"), defaultKeyStores)
+
+				var wallet accounts.Wallet
+				var acct *accounts.Account
+
+				needPassphrase := true
+
+			Scan:
+				for _, x := range wallets {
+					if x.URL().Scheme == "keystore" {
+						for _, y := range x.Accounts() {
+							if y.Address == from {
+								wallet = x
+								acct = &y
+								break Scan
+							}
+						}
+					} else if x.URL().Scheme == "ledger" {
+						x.Open("")
+						for j := 0; j <= 3; j++ {
+							pathstr := fmt.Sprintf("m/44'/60'/0'/%d", j)
+							path, _ := accounts.ParseDerivationPath(pathstr)
+							y, err := x.Derive(path, true)
+							if err != nil {
+								return cli.NewExitError("ethsign: Ledger needs to be in Ethereum app with browser support off", 1)
+							}
+							if y.Address == from {
+								wallet = x
+								acct = &y
+								needPassphrase = false
+								break Scan
+							}
+						}
+					}
+				}
+
+				if acct == nil {
+					return cli.NewExitError(
+						"ethsign: account not found",
+						1,
+					)
+				}
+
+				passphrase := ""
+
+				if needPassphrase {
+					if c.String("passphrase-file") != "" {
+						passphraseFile, err := ioutil.ReadFile(c.String("passphrase-file"))
+						if err != nil {
+							return cli.NewExitError("ethsign: failed to read passphrase file", 1)
+						}
+
+						passphrase = strings.TrimSuffix(string(passphraseFile), "\n")
+					} else {
+						fmt.Fprintf(os.Stderr, "Ethereum account passphrase (not echoed): ")
+						bytes, err := terminal.ReadPassword(int(syscall.Stdin))
+						if err != nil {
+							return cli.NewExitError("ethsign: failed to read passphrase", 1)
+						}
+						passphrase = string(bytes)
+					}
+				} else {
+					fmt.Fprintf(os.Stderr, "Waiting for hardware wallet confirmation...\n")
+				}
+
+				signature, err := wallet.SignHashWithPassphrase(*acct, passphrase, signHash(data))
+
+				if err != nil {
+					return cli.NewExitError("ethsign: failed to sign tx", 1)
+				}
+
+				signature[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
+
+				fmt.Println(hexutil.Encode(signature))
+
 				return nil
 			},
 		},
 	}
-	
+
 	app.Run(os.Args)
 }


### PR DESCRIPTION
This is a big one :)

Primarily, it adds a `ethsign message` or `ethsign msg` command, which allows signing arbitrary data (in hex) similarly to the RPC call `eth_sign`. (see https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign ) It hashes whatever data the use inputs along with a known header to prevent accidental signing of transactions. This is the standard behavior in Geth and Parity.

This is very useful for interacting with smart contracts that make use of `ecrecover` such as the new price feeds.

My Golang plugin also formatted some of the code according to best practices (sorry about that). I can try to put it back as it was.

Also, refactored some code into a function, could be refactored further, especially the part where you get the wallet and wait for a passphrase or ledger/trezor.